### PR TITLE
Fix: Allow EventBridge to Publish to SNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ## Introduction
 
-This module enables AWS Security Hub in one region of one account and optionally sets up an SNS topic to receive 
+This module enables AWS Security Hub in one region of one account and optionally sets up an SNS topic to receive
 notifications of its findings.
 
 
@@ -108,13 +108,16 @@ Here's how to invoke this module in your projects:
 ```hcl
 module "securityhub" {
   source = "cloudposse/security-hub/aws"
-  
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
   create_sns_topic = true
   subscribers = {
     opsgenie = {
-      protocol = "https"
-      endpoint = "https://api.example.com/v1/"
+      protocol               = "https"
+      endpoint               = "https://api.example.com/v1/"
       endpoint_auto_confirms = true
+      raw_message_delivery   = false
     }
   }
 }
@@ -161,6 +164,8 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_imported_findings_label"></a> [imported\_findings\_label](#module\_imported\_findings\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_sns_kms_key"></a> [sns\_kms\_key](#module\_sns\_kms\_key) | cloudposse/kms-key/aws | 0.10.0 |
+| <a name="module_sns_kms_key_label"></a> [sns\_kms\_key\_label](#module\_sns\_kms\_key\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_sns_topic"></a> [sns\_topic](#module\_sns\_topic) | cloudposse/sns-topic/aws | 0.16.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
@@ -172,6 +177,8 @@ Available targets:
 | [aws_cloudwatch_event_target.imported_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_securityhub_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
 | [aws_securityhub_standards_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.sns_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -308,7 +315,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.md
+++ b/README.md
@@ -375,12 +375,14 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Matt Calhoun][mcalhoun_avatar]][mcalhoun_homepage]<br/>[Matt Calhoun][mcalhoun_homepage] |
-|---|
+|  [![Matt Calhoun][mcalhoun_avatar]][mcalhoun_homepage]<br/>[Matt Calhoun][mcalhoun_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
+|---|---|
 <!-- markdownlint-restore -->
 
   [mcalhoun_homepage]: https://github.com/mcalhoun
   [mcalhoun_avatar]: https://img.cloudposse.com/150x150/https://github.com/mcalhoun.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -17,7 +17,7 @@ license: "APACHE2"
 copyrights:
   - name: "Cloud Posse, LLC"
     url: "https://cloudposse.com"
-    year: "2020"
+    year: "2021"
 
 # Canonical GitHub repo
 github_repo: cloudposse/terraform-aws-security-hub
@@ -61,14 +61,14 @@ description: |-
 
 # Introduction to the project
 introduction: |-
-  This module enables AWS Security Hub in one region of one account and optionally sets up an SNS topic to receive 
+  This module enables AWS Security Hub in one region of one account and optionally sets up an SNS topic to receive
   notifications of its findings.
 
 # How to use this module. Should be an easy example to copy and paste.
 usage: |-
 
   For a complete example, see [examples/complete](examples/complete).
-  
+
   For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
 
   Here's how to invoke this module in your projects:
@@ -76,13 +76,16 @@ usage: |-
   ```hcl
   module "securityhub" {
     source = "cloudposse/security-hub/aws"
-    
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
+
     create_sns_topic = true
     subscribers = {
       opsgenie = {
-        protocol = "https"
-        endpoint = "https://api.example.com/v1/"
+        protocol               = "https"
+        endpoint               = "https://api.example.com/v1/"
         endpoint_auto_confirms = true
+        raw_message_delivery   = false
       }
     }
   }

--- a/README.yaml
+++ b/README.yaml
@@ -109,3 +109,5 @@ include:
 contributors:
   - name: "Matt Calhoun"
     github: "mcalhoun"
+  - name: "Yonatan Koren"
+    github: "korenyoni"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,8 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_imported_findings_label"></a> [imported\_findings\_label](#module\_imported\_findings\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_sns_kms_key"></a> [sns\_kms\_key](#module\_sns\_kms\_key) | cloudposse/kms-key/aws | 0.10.0 |
+| <a name="module_sns_kms_key_label"></a> [sns\_kms\_key\_label](#module\_sns\_kms\_key\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_sns_topic"></a> [sns\_topic](#module\_sns\_topic) | cloudposse/sns-topic/aws | 0.16.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
@@ -28,6 +30,8 @@
 | [aws_cloudwatch_event_target.imported_findings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_securityhub_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_account) | resource |
 | [aws_securityhub_standards_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.sns_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -30,7 +30,7 @@ module "sns_kms_key" {
 data "aws_iam_policy_document" "sns_kms_key_policy" {
   count = local.create_sns_topic ? 1 : 0
 
-  policy_id = "EventBridgeDecrypt"
+  policy_id = "EventBridgeEncryptUsingKey"
 
   statement {
     effect = "Allow"

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -1,0 +1,108 @@
+#-----------------------------------------------------------------------------------------------------------------------
+# Optionally configure Event Bridge (formerly CloudWatchEvents) Rules and SNS subscriptions
+# We would like the SNS Topic to be encrypted, and EventBridge requires sufficient permissions for the KMS key
+# https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cwe-integration-types.html
+# https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html
+#-----------------------------------------------------------------------------------------------------------------------
+
+module "sns_kms_key_label" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1"
+
+  attributes = ["securityhub-sns-kms-key"]
+  context    = module.this.context
+}
+
+module "sns_kms_key" {
+  source  = "cloudposse/kms-key/aws"
+  version = "0.10.0"
+  count   = local.create_sns_topic ? 1 : 0
+
+  name                = module.sns_kms_key_label.id
+  description         = "KMS key for the security-hub Imported Findings SNS topic"
+  enable_key_rotation = true
+  alias               = "alias/security-hub-sns"
+  policy              = local.create_sns_topic ? data.aws_iam_policy_document.sns_kms_key_policy[0].json : ""
+
+  context = module.this.context
+}
+
+data "aws_iam_policy_document" "sns_kms_key_policy" {
+  count = local.create_sns_topic ? 1 : 0
+
+  policy_id = "EventBridgeDecrypt"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+module "sns_topic" {
+  source  = "cloudposse/sns-topic/aws"
+  version = "0.16.0"
+  count   = local.create_sns_topic ? 1 : 0
+
+  attributes        = ["securityhub"]
+  subscribers       = var.subscribers
+  sqs_dlq_enabled   = false
+  kms_master_key_id = local.create_sns_topic ? module.sns_kms_key[0].alias_name : ""
+
+  allowed_aws_services_for_sns_published = ["events.amazonaws.com"]
+
+  context = module.this.context
+}
+
+module "imported_findings_label" {
+  source  = "cloudposse/label/null"
+  version = "0.24.1"
+
+  attributes = ["securityhub-imported-findings"]
+  context    = module.this.context
+}
+
+resource "aws_cloudwatch_event_rule" "imported_findings" {
+  count       = local.enable_notifications == true ? 1 : 0
+  name        = module.imported_findings_label.id
+  description = "SecurityHubEvent - Imported Findings"
+  tags        = module.this.tags
+
+  event_pattern = jsonencode(
+    {
+      "source" : [
+        "aws.securityhub"
+      ],
+      "detail-type" : [
+        var.cloudwatch_event_rule_pattern_detail_type
+      ]
+    }
+  )
+}
+
+resource "aws_cloudwatch_event_target" "imported_findings" {
+  count = local.enable_notifications == true ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.imported_findings[0].name
+  arn   = local.imported_findings_notification_arn
+}

--- a/main.tf
+++ b/main.tf
@@ -6,64 +6,13 @@ resource "aws_securityhub_account" "this" {
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
-# Optionally subscribe to Security Hub Standards 
+# Optionally subscribe to Security Hub Standards
 # https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards.html
 #-----------------------------------------------------------------------------------------------------------------------
 resource "aws_securityhub_standards_subscription" "this" {
   for_each      = local.enabled_standards_arns
   depends_on    = [aws_securityhub_account.this]
   standards_arn = each.key
-}
-
-#-----------------------------------------------------------------------------------------------------------------------
-# Optionally configure Event Bridge Rules and SNS subscriptions 
-# https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cwe-integration-types.html
-# https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/resource-based-policies-cwe.html#sns-permissions
-#-----------------------------------------------------------------------------------------------------------------------
-module "sns_topic" {
-  source  = "cloudposse/sns-topic/aws"
-  version = "0.16.0"
-  count   = local.create_sns_topic ? 1 : 0
-
-  attributes      = ["securityhub"]
-  subscribers     = var.subscribers
-  sqs_dlq_enabled = false
-
-  allowed_aws_services_for_sns_published = ["cloudwatch.amazonaws.com"]
-
-  context = module.this.context
-}
-
-module "imported_findings_label" {
-  source  = "cloudposse/label/null"
-  version = "0.24.1"
-
-  attributes = ["securityhub-imported-findings"]
-  context    = module.this.context
-}
-
-resource "aws_cloudwatch_event_rule" "imported_findings" {
-  count       = local.enable_notifications == true ? 1 : 0
-  name        = module.imported_findings_label.id
-  description = "SecurityHubEvent - Imported Findings"
-  tags        = module.this.tags
-
-  event_pattern = jsonencode(
-    {
-      "source" : [
-        "aws.securityhub"
-      ],
-      "detail-type" : [
-        var.cloudwatch_event_rule_pattern_detail_type
-      ]
-    }
-  )
-}
-
-resource "aws_cloudwatch_event_target" "imported_findings" {
-  count = local.enable_notifications == true ? 1 : 0
-  rule  = aws_cloudwatch_event_rule.imported_findings[0].name
-  arn   = local.imported_findings_notification_arn
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -79,5 +28,6 @@ locals {
   ])
 }
 
+data "aws_caller_identity" "this" {}
 data "aws_partition" "this" {}
 data "aws_region" "this" {}


### PR DESCRIPTION
## what
* Create KMS key for SNS topic and allow EventBridge the required permissions for it to write to the encrypted topic, using Resource-based policies
* Change the service allowed to publish to the SNS topic to `events.amazonaws.com` from `cloudwatch.amazonaws.com` (the latter service is not the one identifying EventBridge aka CloudWatchEvents).
* Fix usage snippet, which wasn't passing all of the required nested attributes for the objects in `var.subscribers`
* Split up main.tf since more resources now exist

## why
* EventBridge (formerly CloudWatchEvents) was not able to Publish to the SNS Topic

## references
* N/A
