### PR TITLE
Fix: Null Label Conventional Fix

### DIFF
--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -19,7 +19,7 @@ module "sns_kms_key" {
   version = "0.10.0"
   count   = local.create_sns_topic ? 1 : 0
 
-  name                = local.create_sns_topic ? module.sns_kms_key_label.id : ""
+  name                = local.create_sns_topic ? module.sns_kms_key_label[0].id : ""
   description         = "KMS key for the security-hub Imported Findings SNS topic"
   enable_key_rotation = true
   alias               = "alias/security-hub-sns"

--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -8,8 +8,9 @@
 module "sns_kms_key_label" {
   source  = "cloudposse/label/null"
   version = "0.24.1"
+  count   = local.create_sns_topic ? 1 : 0
 
-  attributes = ["securityhub-sns-kms-key"]
+  attributes = ["securityhub"]
   context    = module.this.context
 }
 
@@ -18,7 +19,7 @@ module "sns_kms_key" {
   version = "0.10.0"
   count   = local.create_sns_topic ? 1 : 0
 
-  name                = module.sns_kms_key_label.id
+  name                = local.create_sns_topic ? module.sns_kms_key_label.id : ""
   description         = "KMS key for the security-hub Imported Findings SNS topic"
   enable_key_rotation = true
   alias               = "alias/security-hub-sns"


### PR DESCRIPTION
## what
* Do not create null label for kms key if sns topic creation is disabled;
* Do not include the resource name in the attributes as it is already implied by the resource it is going to be attached to.

## why
* Ensure all resources and data resources consistently adhere `module.this.enabled`
* Conventional fix for use of null label

## references
* #20 
* https://github.com/cloudposse/terraform-aws-cloudtrail-cloudwatch-alarms/pull/36

