### PR TITLE
Add event rule pattern detail and control finding generator variable

### DIFF
--- a/eventbridge.tf
+++ b/eventbridge.tf
@@ -91,14 +91,19 @@ resource "aws_cloudwatch_event_rule" "imported_findings" {
   tags        = module.this.tags
 
   event_pattern = jsonencode(
-    {
-      "source" : [
-        "aws.securityhub"
-      ],
-      "detail-type" : [
-        var.cloudwatch_event_rule_pattern_detail_type
-      ]
-    }
+    merge(
+      {
+        "source" : [
+          "aws.securityhub"
+        ],
+        "detail-type" : [
+          var.cloudwatch_event_rule_pattern_detail_type
+        ]
+      },
+      var.cloudwatch_event_rule_pattern_detail != null ?
+      { "detail" : var.cloudwatch_event_rule_pattern_detail } :
+      {}
+    )
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,8 @@
 resource "aws_securityhub_account" "this" {
   count = local.enabled ? 1 : 0
 
-  enable_default_standards = var.enable_default_standards
+  enable_default_standards  = var.enable_default_standards
+  control_finding_generator = var.control_finding_generator
 }
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -10,14 +10,16 @@ variable "enable_default_standards" {
 }
 
 variable "control_finding_generator" {
-  description = "Updates whether the calling account has consolidated control findings turned on.
+  description = <<-DOC
+  Updates whether the calling account has consolidated control findings turned on.
   If the value for this field is set to ,
-  
+
   SECURITY_CONTROL - Security Hub generates a single finding for a control check even when
   the check applies to multiple enabled standards.
 
-  STANDARD_CONTROL - Security Hub generates separate findings for a control check when the 
-  check applies to multiple enabled standards."
+  STANDARD_CONTROL - Security Hub generates separate findings for a control check when the
+  check applies to multiple enabled standards.
+  DOC
   type        = string
   default     = "SECURITY_CONTROL"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,17 @@ variable "cloudwatch_event_rule_pattern_detail_type" {
   default     = "Security Hub Findings - Imported"
 }
 
+variable "cloudwatch_event_rule_pattern_detail" {
+  description = <<-DOC
+  The detail pattern used to match events that will be sent to SNS. 
+
+  For more information, see:
+  https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
+  DOC
+  type        = object()
+  default     = null
+}
+
 variable "finding_aggregator_enabled" {
   description = <<-DOC
   Flag to indicate whether a finding aggregator should be created

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,19 @@ variable "enable_default_standards" {
   default     = true
 }
 
+variable "control_finding_generator" {
+  description = "Updates whether the calling account has consolidated control findings turned on.
+  If the value for this field is set to ,
+  
+  SECURITY_CONTROL - Security Hub generates a single finding for a control check even when
+  the check applies to multiple enabled standards.
+
+  STANDARD_CONTROL - Security Hub generates separate findings for a control check when the 
+  check applies to multiple enabled standards."
+  type        = string
+  default     = "SECURITY_CONTROL"
+}
+
 variable "enabled_standards" {
   description = <<-DOC
   A list of standards/rulesets to enable

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "imported_findings_notification_arn" {
   description = <<-DOC
   The ARN for an SNS topic to send findings notifications to. This is only used if create_sns_topic is false.
 
-  If you want to send findings to an existing SNS topic, set the value of this to the ARN of the existing topic and set 
+  If you want to send findings to an existing SNS topic, set the value of this to the ARN of the existing topic and set
   create_sns_topic to false.
   DOC
   default     = null
@@ -64,7 +64,7 @@ variable "imported_findings_notification_arn" {
 
 variable "cloudwatch_event_rule_pattern_detail_type" {
   description = <<-DOC
-  The detail-type pattern used to match events that will be sent to SNS. 
+  The detail-type pattern used to match events that will be sent to SNS.
 
   For more information, see:
   https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
@@ -75,12 +75,12 @@ variable "cloudwatch_event_rule_pattern_detail_type" {
 
 variable "cloudwatch_event_rule_pattern_detail" {
   description = <<-DOC
-  The detail pattern used to match events that will be sent to SNS. 
+  The detail pattern used to match events that will be sent to SNS.
 
   For more information, see:
   https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html
   DOC
-  type        = object()
+  type        = any
   default     = null
 }
 
@@ -100,9 +100,9 @@ variable "finding_aggregator_enabled" {
 
 variable "finding_aggregator_linking_mode" {
   description = <<-DOC
-  Linking mode to use for the finding aggregator. 
+  Linking mode to use for the finding aggregator.
 
-  The possible values are: 
+  The possible values are:
     - `ALL_REGIONS` - Aggregate from all regions
     - `ALL_REGIONS_EXCEPT_SPECIFIED` - Aggregate from all regions except those specified in `var.finding_aggregator_regions`
     - `SPECIFIED_REGIONS` - Aggregate from regions specified in `finding_aggregator_enabled`
@@ -113,7 +113,7 @@ variable "finding_aggregator_linking_mode" {
 
 variable "finding_aggregator_regions" {
   description = <<-DOC
-  A list of regions to aggregate findings from. 
+  A list of regions to aggregate findings from.
 
   This is only used if `finding_aggregator_enabled` is `true`.
   DOC


### PR DESCRIPTION
## what
Add two variables for better customization of the module.


## why
`cloudwatch_event_rule_pattern_detail` - allow a more specific detail pattern in order to filter events sent through the SNS topic.  Currently using to only match events which have failed and are 'HIGH' and 'CRITICAL'.

`control_finding_generator` - optionality that exists on `aws_securityhub_account`. Ensures that users of this module don't sacrifice functionality.

