### PR TITLE
fix: remove deprecated controls from disablements

### DIFF
--- a/modules/control-disablements/README.md
+++ b/modules/control-disablements/README.md
@@ -1,7 +1,7 @@
 
 # Summary
 
-There are certain controls that it only make sense to monitor once per account, not once per region per account.
+There are certain controls that only make sense to monitor once per account, not once per region per account.
 As an example, imagine you wanted to verify an IAM Role exists for a given account. That wouldn't need
 to be verified in each region for the account. As such, this module takes your current AWS Provider configuration
 and uses it to generate and output a list of controls to disable.

--- a/modules/control-disablements/README.md
+++ b/modules/control-disablements/README.md
@@ -1,0 +1,99 @@
+
+# Summary
+
+There are certain controls that it only make sense to monitor once per account, not once per region per account.
+As an example, imagine you wanted to verify an IAM Role exists for a given account. That wouldn't need
+to be verified in each region for the account. As such, this module takes your current AWS Provider configuration
+and uses it to generate and output a list of controls to disable.
+
+Because this list doesn't change much, we have a static definition of the controls to disable in the `main.tf` file.
+
+# Scope
+
+Right now, this module only targets CIS 1.2 controls.
+
+# Usage
+
+```hcl
+module "control_disablements" {
+  source  = "cloudposse/security-hub/aws//modules/control-disablements"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  global_resource_collector_region = var.global_resource_collector_region # i.e. us-east-1
+  central_logging_account          = local.central_logging_account
+
+  environment = ""
+
+  context = module.this.context
+}
+
+resource "awsutils_security_hub_control_disablement" "global" {
+  for_each    = toset(module.control_disablements.controls)
+  control_arn = each.key
+  reason      = "Global and CloudTrail resources are not collected in this account/region"
+
+  depends_on = [
+    module.security_hub
+  ]
+}
+```
+
+# Terraform Docs
+
+<!-- below was generated with `terraform-docs markdown . >> README.md` -->
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_central_logging_account"></a> [central\_logging\_account](#input\_central\_logging\_account) | The id of the account that is the centralized cloudtrail logging account. | `string` | n/a | yes |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_global_resource_collector_region"></a> [global\_resource\_collector\_region](#input\_global\_resource\_collector\_region) | The region that collects AWS Config data for global resources such as IAM | `string` | n/a | yes |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_controls"></a> [controls](#output\_controls) | A list of controls to disable based on the the input variables |

--- a/modules/control-disablements/main.tf
+++ b/modules/control-disablements/main.tf
@@ -44,7 +44,6 @@ locals {
   included_global_region_controls = local.is_global_resource_region ? [] : (data.aws_region.this.name == "ap-northeast-3" ? local.all_global_region_controls : concat(local.an3_excluded_controls, local.all_global_region_controls))
 
   all_cloudtrail_controls = [
-    "${local.control_prefix}/cis-aws-foundations-benchmark/v/1.2.0/1.1",
     "${local.control_prefix}/cis-aws-foundations-benchmark/v/1.2.0/2.7",
     "${local.control_prefix}/cis-aws-foundations-benchmark/v/1.2.0/3.1",
     "${local.control_prefix}/cis-aws-foundations-benchmark/v/1.2.0/3.2",


### PR DESCRIPTION
## what

- fix(control-disablements): cis 1.2/1.1 dropped
- docs(control-disablements): add summary, usage, and tf docs

## why

- module causes the `awsutils_security_hub_control_disablement` resource to
error out when it emits unsupported controls
- documentation helps explain the presence of the module (since it isn't
        directly used anywhere else)

